### PR TITLE
Makefile has now target 'clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ build-web:
 trunk:
 	(cd mailtutan-web && trunk serve)
 
+clean:
+	cargo clean
+	(cd mailtutan-web && trunk clean)
+	rm -rf mailtutan-lib/dist/*
+
 publish:
 	cargo publish -p mailtutan-web
 	cargo publish -p mailtutan-lib


### PR DESCRIPTION
Is convenient when you want a fresh start for building. With `make clean` are the generated files removed.

The new lines in Makefile:
  clean:
	cargo clean
	(cd mailtutan-web && trunk clean)
	rm -rf mailtutan-lib/dist/*