### PR TITLE
Document origin of the toml executable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ publish:
 	cargo publish -p mailtutan-lib
 	cargo publish -p mailtutan
 
+# FYI Get `toml` executable by `cargo install --locked toml-cli`
 VERSION := $(shell toml get Cargo.toml workspace.package.version --raw)
 
 docker-build:


### PR DESCRIPTION
The toml programm in the Makefile originates from toml-cli crate.