### PR TITLE
Fix issue #75 + minor improvements

### DIFF
--- a/mailtutan-lib/src/api/messages.rs
+++ b/mailtutan-lib/src/api/messages.rs
@@ -5,112 +5,124 @@ use crate::AppState;
 use axum::extract::Path;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::Html;
 use axum::response::IntoResponse;
+use axum::response::{Html, Response};
 use axum::Json;
 
 pub async fn index(State(state): State<Arc<AppState>>) -> Json<Vec<Message>> {
     Json(state.storage.read().unwrap().list().to_vec())
 }
 
-pub async fn show_source(
-    Path(id): Path<usize>,
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    (
-        StatusCode::OK,
-        [("Content-Type", "text/plain;charset=utf-8")],
-        state.storage.read().unwrap().get(id).source,
-    )
+pub async fn show_source(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Response {
+    if let Some(msg) = state.storage.read().expect("unpoisoned lock").get(id) {
+        (
+            StatusCode::OK,
+            [("Content-Type", "text/plain;charset=utf-8")],
+            msg.source,
+        )
+            .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
 pub async fn delete(
     Path(id): Path<usize>,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    state.storage.write().unwrap().remove(id);
+    state.storage.write().expect("unpoisoned lock").remove(id);
 
     StatusCode::OK
 }
 
-pub async fn show_plain(
-    Path(id): Path<usize>,
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    (
-        StatusCode::OK,
-        [("Content-Type", "text/plain;charset=utf-8")],
-        state
-            .storage
-            .read()
-            .unwrap()
-            .get(id)
-            .plain
-            .as_ref()
-            .unwrap()
-            .clone(),
-    )
+pub async fn show_plain(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Response {
+    if let Some(msg) = state
+        .storage
+        .read()
+        .expect("unpoisoned lock")
+        .get(id)
+        .and_then(|m| m.plain)
+    {
+        (
+            StatusCode::OK,
+            [("Content-Type", "text/plain;charset=utf-8")],
+            msg,
+        )
+            .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
-pub async fn show_html(
-    Path(id): Path<usize>,
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    (
-        StatusCode::OK,
-        [("Content-Type", "text/html;charset=utf-8")],
-        state
-            .storage
-            .read()
-            .unwrap()
-            .get(id)
-            .html
-            .as_ref()
-            .unwrap()
-            .clone(),
-    )
+pub async fn show_html(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Response {
+    if let Some(msg) = state
+        .storage
+        .read()
+        .expect("unpoisoned lock")
+        .get(id)
+        .and_then(|m| m.html)
+    {
+        (
+            StatusCode::OK,
+            [("Content-Type", "text/html;charset=utf-8")],
+            msg,
+        )
+            .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
-pub async fn show_eml(
-    Path(id): Path<usize>,
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    (
-        StatusCode::OK,
-        [("Content-Type", "message/rfc822")],
-        state.storage.read().unwrap().get(id).source,
-    )
+pub async fn show_eml(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Response {
+    if let Some(msg) = state.storage.read().expect("unpoisoned lock").get(id) {
+        (
+            StatusCode::OK,
+            [("Content-Type", "message/rfc822")],
+            msg.source,
+        )
+            .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
 pub async fn download_attachment(
     Path((id, cid)): Path<(usize, String)>,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    for attachment in &state.storage.read().unwrap().get(id).attachments {
-        if attachment.cid == cid {
-            return (
-                StatusCode::OK,
-                [(
-                    "Content-Disposition",
-                    format!("attachment; filename=\"{}\"", attachment.filename),
-                )],
-                attachment.body.clone(),
-            );
-        }
+    if let Some(attachment) = state
+        .storage
+        .read()
+        .expect("unpoisoned lock")
+        .get(id)
+        .and_then(|msg| msg.attachments.iter().find(|a| a.cid == cid).cloned())
+    {
+        (
+            StatusCode::OK,
+            [(
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", attachment.filename),
+            )],
+            attachment.body,
+        )
+    } else {
+        (
+            StatusCode::OK,
+            [("Content-Type", "message/rfc822".to_string())],
+            vec![],
+        )
     }
-
-    (
-        StatusCode::OK,
-        [("Content-Type", "message/rfc822".to_string())],
-        vec![],
-    )
 }
 
-pub async fn show_json(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Json<Message> {
-    Json(state.storage.read().unwrap().get(id))
+pub async fn show_json(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Response {
+    if let Some(msg) = state.storage.read().expect("unpoisoned lock").get(id) {
+        Json(msg).into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
 pub async fn delete_all(State(state): State<Arc<AppState>>) -> Html<&'static str> {
-    state.storage.write().unwrap().delete_all();
+    state.storage.write().expect("unpoisoned lock").delete_all();
     Html("Ok")
 }

--- a/mailtutan-lib/src/storage.rs
+++ b/mailtutan-lib/src/storage.rs
@@ -8,7 +8,7 @@ pub use memory::Memory;
 pub trait Storage: Sync + Send {
     fn list(&self) -> Vec<Message>;
     fn add(&mut self, message: Message) -> Message;
-    fn get(&self, item: usize) -> Message;
+    fn get(&self, item: usize) -> Option<Message>;
     fn remove(&mut self, item: usize);
     fn size(&self) -> usize;
     fn delete_all(&mut self);
@@ -16,23 +16,46 @@ pub trait Storage: Sync + Send {
 
 #[cfg(test)]
 mod tests {
-    use super::Memory;
     use super::Storage;
+    use super::{Memdir, Memory};
     use crate::models::Message;
-    use std::assert_eq;
+    use std::{assert_eq, fs};
 
     #[test]
-    fn test_store() {
+    fn test_memory_store() {
         let mut store = Memory::new(1000);
+        test_storage(&mut store);
+    }
 
-        store.add(Message {
-            ..Default::default()
-        });
+    #[test]
+    fn test_memdir_store() {
+        let dir = "./tmp";
+        let mut store = Memdir::new(1000, dir);
+        test_storage(&mut store);
+        fs::remove_dir(dir).unwrap();
+    }
 
-        assert_eq!(store.size(), 1);
-
+    fn test_storage<T: Storage>(store: &mut T) {
         store.delete_all();
+        let data = concat!(
+            "From: Private Person <me@fromdomain.com>\n",
+            "To: A Test User <test@todomain.com>\n",
+            "Subject: Hello, Testing, Testing\n",
+            "\n",
+            "This is a test e-mail message.\n"
+        )
+        .as_bytes()
+        .to_vec();
 
+        let message = Message::from(&data).unwrap();
+        let added = store.add(message);
+        assert_eq!(store.size(), 1);
+        let received = store.get(added.id.unwrap()).unwrap();
+        assert_eq!(received.subject, "Hello, Testing, Testing");
+        let received = &store.list()[0];
+        assert_eq!(received.subject, "Hello, Testing, Testing");
+        store.remove(received.id.unwrap());
         assert_eq!(store.size(), 0);
+        assert!(store.get(42).is_none());
     }
 }

--- a/mailtutan-lib/src/storage/memory.rs
+++ b/mailtutan-lib/src/storage/memory.rs
@@ -21,13 +21,7 @@ impl Memory {
 
 impl Storage for Memory {
     fn list(&self) -> Vec<Message> {
-        let mut list: Vec<Message> = vec![];
-
-        for record in self.records.values() {
-            list.push(record.clone());
-        }
-
-        list
+        self.records.values().cloned().collect()
     }
 
     fn add(&mut self, mut message: Message) -> Message {
@@ -45,12 +39,12 @@ impl Storage for Memory {
         message
     }
 
-    fn get(&self, item: usize) -> Message {
-        self.records.get(&item).unwrap().clone()
+    fn get(&self, item: usize) -> Option<Message> {
+        self.records.get(&item).cloned()
     }
 
     fn remove(&mut self, item: usize) {
-        self.records.remove(&item).unwrap();
+        self.records.remove(&item);
     }
 
     fn size(&self) -> usize {


### PR DESCRIPTION
- `Storage` now returns `Option<Message>` for `.get(id)` to handle absence of values correctly and its implementors have been adjusted accordingly
- remove uses of `unwrap()` in adjacent code
- expand tests for `Storage` implementations